### PR TITLE
Restore "immediate" argument and behaviour 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ following are available:
 If there are marked files, operations only affect those files.  Otherwise files in selections
 or with cursors on them are affected.  This works nicely with multiple cursors and selections.
 
+### Immediate
+
+The `dired` command accepts the argument `immediate`, which immediately displays a directory
+without prompting.  The directory displayed will be that of the current view or the first
+project folder, or if neither of these are available, the user’s home directory.
+
+This also allows the plugin to be used from the command line or integrated with a file browser
+etc., e.g.
+
+```
+subl --command 'dired {"immediate": true}' "/path/to/folder"
+```
+
 ### Rename
 
 The rename command puts the view into "rename mode".  The view is made editable so files can be

--- a/dired.py
+++ b/dired.py
@@ -57,8 +57,11 @@ class DiredCommand(WindowCommand):
     """
     Prompt for a directory to display and display it.
     """
-    def run(self):
-        prompt.start('Directory:', self.window, self._determine_path(), self._show)
+    def run(self, **args):
+        if args.get('immediate', False):
+            show(self.window, self._determine_path())
+        else:
+            prompt.start('Directory:', self.window, self._determine_path(), self._show)
 
     def _show(self, path):
         show(self.window, path)


### PR DESCRIPTION
Thanks for saving this plugin!  I used to use this all the time via an "action" in my file browser (Nemo or Nautilus) that relied on the `immediate` argument to the `dired` command, but that seems to be missing in this version, so I reimplemented it (I'm not sure if my implementation is identical to the original version or not).  The default behaviour is not affected in any way.