### PR TITLE
Fix error with on_selection_modified

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -517,11 +517,11 @@ class DiredPreviewCloseCommand(TextCommand, DiredBaseCommand):
 class DiredPreviewEventListener(EventListener, DiredBaseCommand):
     def on_selection_modified(self, view):
         self.view = view
-        if 'text.dired' in self.view.scope_name(self.view.sel()[0].a) :
-            if self.view.settings().get('preview_key') :
+        selections = self.view.sel()
+        if selections and len(selections) > 0 and 'text.dired' in self.view.scope_name(selections[0].a):
+            if self.view.settings().get('preview_key'):
                 path_list = get_path_list(self.path, self.get_selected(), False)
-
-                if path_list :
+                if path_list:
                     self.view.settings().set('preview_key', False)
                     self.view.window().run_command('dired_preview_refresh', {'path':path_list[0]})
                     self.view.settings().set('preview_key', True)


### PR DESCRIPTION
I noticed this error in the console while using the plugin:

```
  File "/Applications/Sublime Text 3.app/Contents/MacOS/sublime_plugin.py", line 478, in run_callback
    expr()
  File "/Applications/Sublime Text 3.app/Contents/MacOS/sublime_plugin.py", line 602, in <lambda>
    run_callback('on_selection_modified', callback, lambda: callback.on_selection_modified(v))
  File "/Users/juliangarnier/Library/Application Support/Sublime Text 3/Installed Packages/dired.sublime-package/dired.py", line 520, in on_selection_modified
    if 'text.dired' in self.view.scope_name(self.view.sel()[0].a) :
  File "/Applications/Sublime Text 3.app/Contents/MacOS/sublime.py", line 649, in __getitem__
    raise IndexError()
```

This PR fixes it.